### PR TITLE
Have CNAME handle futureware.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-static.futureware.dev
+futureware.dev


### PR DESCRIPTION
Both static and non-static will now be hosted by GitHub pages.

Static is redirected using CF rules.